### PR TITLE
build(halo2-proofs): pin halo2-proofs version

### DIFF
--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -10,13 +10,13 @@ edition = "2021"
 ethers-signers  = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 halo2curves = { git = "https://github.com/scroll-tech/halo2curves", branch = "v0.1.0" }
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
-halo2_proofs = {  git = "https://github.com/snarkify/halo2-scroll.git", commit = "d27d547" }
+halo2_proofs = {  git = "https://github.com/snarkify/halo2-scroll.git", tag = "snarkify-v0.1" }
 [patch."https://github.com/privacy-scaling-explorations/poseidon.git"]
 poseidon = { git = "https://github.com/scroll-tech/poseidon.git", branch = "main" }
 [patch."https://github.com/privacy-scaling-explorations/bls12_381"]
 bls12_381 = { git = "https://github.com/scroll-tech/bls12_381", branch = "feat/impl_scalar_field" }
 [patch."https://github.com/scroll-tech/halo2.git"]
-halo2_proofs = {  git = "https://github.com/snarkify/halo2-scroll.git", commit = "d27d547" }
+halo2_proofs = {  git = "https://github.com/snarkify/halo2-scroll.git", tag = "snarkify-v0.1" }
 
 [dependencies]
 anyhow = "1.0"

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -10,14 +10,13 @@ edition = "2021"
 ethers-signers  = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 halo2curves = { git = "https://github.com/scroll-tech/halo2curves", branch = "v0.1.0" }
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
-halo2_proofs = {  git = "https://github.com/snarkify/halo2-scroll.git", branch = "snarkify" }
+halo2_proofs = {  git = "https://github.com/snarkify/halo2-scroll.git", commit = "d27d547" }
 [patch."https://github.com/privacy-scaling-explorations/poseidon.git"]
 poseidon = { git = "https://github.com/scroll-tech/poseidon.git", branch = "main" }
 [patch."https://github.com/privacy-scaling-explorations/bls12_381"]
 bls12_381 = { git = "https://github.com/scroll-tech/bls12_381", branch = "feat/impl_scalar_field" }
 [patch."https://github.com/scroll-tech/halo2.git"]
-halo2_proofs = {  git = "https://github.com/snarkify/halo2-scroll.git", branch = "snarkify" }
-
+halo2_proofs = {  git = "https://github.com/snarkify/halo2-scroll.git", commit = "d27d547" }
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
I figured it may be a good idea to pin our halo2-proofs version to a commit rather than the main snarkify branch so we are not continually changing the live version we use as I make changes to the snarkify branch; my thought is we'd only update the commit we use here after we have triple-checked the functionality of any updates. Let me know if you all agree.

Also, I wasn't sure whether this should be merged into the cusnark-integration branch, snarkify-gpu-deploy branch, or something else. Let me know.
